### PR TITLE
Removing DataAnnotations...

### DIFF
--- a/src/SanityCheck/Program.cs
+++ b/src/SanityCheck/Program.cs
@@ -40,6 +40,7 @@ namespace SanityCheck
                 "MusicStore",
                 "Coherence",
                 "Coherence-Signed",
+                "DataAnnotations",
                 "latest-dev",
                 "Entropy",
                 "latest-packages",


### PR DESCRIPTION
...as it deliberately targets System.ComponentModel.Annotations 4.0.0.0 instead of 4.0.10.0 for portable builds.

@pranavkm @davidfowl @lodejard @bricelam @Eilon 
