### PR TITLE
Update to use latest NuGet.Core

### DIFF
--- a/src/SanityCheck/Program.cs
+++ b/src/SanityCheck/Program.cs
@@ -14,8 +14,6 @@ namespace SanityCheck
     {
         static int Main(string[] args)
         {
-            AddNewFrameworksToNuGet();
-
             if (args.Length < 6)
             {
                 Console.WriteLine("Usage: SanityCheck [dropFolder] [buildBranch] [outputPath] [symbolsOutputPath] [symbolSourcePath] [nugetExePath]");
@@ -167,33 +165,6 @@ namespace SanityCheck
             }
 
             return 0;
-        }
-
-        private static void AddNewFrameworksToNuGet()
-        {
-            // Super hacky way to work around known nuget frameworks
-            // Add DNX and DNX Core to the list of frameworks
-            // so that parsing them won't both show up as unsupported
-            const string DnxFrameworkIdentifier = "DNX";
-            const string DnxCoreFrameworkIdentifier = "DNXCore";
-            const string NetPlatformFrameworkIdentifier = ".NETPlatform";
-
-            var knownIdentifiers = GetDictionaryField("_knownIdentifiers");
-            var identifierToFrameworkFolder = GetDictionaryField("_identifierToFrameworkFolder");
-
-            if (knownIdentifiers != null)
-            {
-                knownIdentifiers["dnx"] = DnxFrameworkIdentifier;
-                knownIdentifiers["dnxcore"] = DnxCoreFrameworkIdentifier;
-                knownIdentifiers["dotnet"] = NetPlatformFrameworkIdentifier;
-            }
-
-            if (identifierToFrameworkFolder != null)
-            {
-                identifierToFrameworkFolder[DnxFrameworkIdentifier] = "dnx";
-                identifierToFrameworkFolder[DnxCoreFrameworkIdentifier] = "dnxcore";
-                identifierToFrameworkFolder[NetPlatformFrameworkIdentifier] = "dotnet";
-            }
         }
 
         private static IDictionary<string, string> GetDictionaryField(string fieldName)

--- a/src/SanityCheck/Program.cs
+++ b/src/SanityCheck/Program.cs
@@ -339,9 +339,8 @@ namespace SanityCheck
                     {
                         if (dependencyPackageInfo.IsCoreCLRPackage)
                         {
-                            if (
-                                !string.Equals(dependencySet.TargetFramework.Identifier, "DNXCORE", StringComparison.OrdinalIgnoreCase) &&
-                                !string.Equals(dependencySet.TargetFramework.Identifier, "DOTNET", StringComparison.OrdinalIgnoreCase))
+                            if (!string.Equals(dependencySet.TargetFramework.Identifier, "DNXCORE", StringComparison.OrdinalIgnoreCase) &&
+                                !string.Equals(dependencySet.TargetFramework.Identifier, ".NETPlatform", StringComparison.OrdinalIgnoreCase))
                             {
                                 packageInfo.InvalidCoreCLRPackageReferences.Add(new DependencyWithIssue
                                 {

--- a/src/SanityCheck/SanityCheck.csproj
+++ b/src/SanityCheck/SanityCheck.csproj
@@ -36,9 +36,9 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60604.702, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.8.6-beta-03\lib\net40-Client\NuGet.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Core, Version=2.8.60605.706, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.Core.2.8.6-beta-04\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SanityCheck/packages.config
+++ b/src/SanityCheck/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.6-beta-03" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.6-beta-04" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The latest NuGet.Core 2.8.6 build understands the .NETPlatform target framework identifier.