### PR TITLE
Temporarily skip PlatformAbstractions

### DIFF
--- a/src/CoherenceBuild/CoherenceVerifier.cs
+++ b/src/CoherenceBuild/CoherenceVerifier.cs
@@ -34,6 +34,12 @@ namespace CoherenceBuild
                         continue;
                     }
 
+                    if (packageInfo.Package.Id.Equals("Microsoft.Extensions.PlatformAbstractions"))
+                    {
+                        // Temporarily skip PlatformAbstractions
+                        continue;
+                    }
+
                     if (packageInfo.InvalidCoreCLRPackageReferences.Count > 0)
                     {
                         Log.WriteError("{0} has invalid package references:", packageInfo.Package.GetFullName());


### PR DESCRIPTION
cc @anurse \ @Eilon 

PlatformAbstractions is a bit messed up at this point. Temporarily skipping it from coherence verification until we sort it out.