### PR TITLE
Bug fix: copy to the correct destination folder is none is specified

### DIFF
--- a/src/CoherenceBuild/FolderDependecy.cs
+++ b/src/CoherenceBuild/FolderDependecy.cs
@@ -28,7 +28,7 @@ namespace CoherenceBuild
                 return;
             }
 
-            var destinationDirectoryPath = Path.Combine(destination, Destination ?? _folder);
+            var destinationDirectoryPath = Path.Combine(destination, string.IsNullOrEmpty(Destination) ? _folder : Destination);
             CopyDirectory(sourceDirectoryPath, destinationDirectoryPath);
         }
 


### PR DESCRIPTION
This will copy folder dependencies in the correct subfolder rather than in the root of the build output

cc @pranavkm 