### PR TITLE
Fix an error in packages.csv

### DIFF
--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -143,7 +143,7 @@ Microsoft.Extensions.CodeGeneration,ship
 Microsoft.Extensions.CodeGeneration.Core,ship
 Microsoft.Extensions.CodeGeneration.EntityFrameworkCore,ship
 Microsoft.Extensions.CodeGeneration.Templating,ship
-Microsoft.Extensions.CodeGeneration.Utils,noship
+Microsoft.Extensions.CodeGeneration.Utils,ship
 Microsoft.Extensions.CodeGenerators.Mvc,ship
 Microsoft.Extensions.CommandLineUtils,ship
 Microsoft.Extensions.CommandLineUtils.Sources,noship


### PR DESCRIPTION
Microsoft.Extensions.CodeGeneration.Utils was incorrectly marked as noship. All the code generation tools that we provide need this.
