### PR TITLE
Reacting to EF functional tests package names changes

### DIFF
--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -121,12 +121,12 @@ Microsoft.Dnx.Compilation.CSharp.Common,ship
 Microsoft.DotNet.*,ext
 Microsoft.EntityFrameworkCore,ship
 Microsoft.EntityFrameworkCore.Commands,ship
-Microsoft.EntityFrameworkCore.FunctionalTests,ship
+Microsoft.EntityFrameworkCore.Specification.Tests,ship
 Microsoft.EntityFrameworkCore.InMemory,ship
 Microsoft.EntityFrameworkCore.Relational,ship
 Microsoft.EntityFrameworkCore.Relational.Design,ship
-Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests,ship
-Microsoft.EntityFrameworkCore.Relational.FunctionalTests,ship
+Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests,ship
+Microsoft.EntityFrameworkCore.Relational.Specification.Tests,ship
 Microsoft.EntityFrameworkCore.Sqlite,ship
 Microsoft.EntityFrameworkCore.Sqlite.Design,ship
 Microsoft.EntityFrameworkCore.SqlServer,ship


### PR DESCRIPTION
Microsoft.EntityFrameworkCore.FunctionalTests -> Microsoft.EntityFrameworkCore.Specification.Tests
Microsoft.EntityFrameworkCore.Relational.FunctionalTests -> Microsoft.EntityFrameworkCore.Relational.Specification.Tests
Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests -> Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests

depends on aspnet/entityframework#5064