### PR TITLE
Remove Microsoft.Extensions.CompilationAbstractions from the list of shipping packages

### DIFF
--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -145,7 +145,7 @@ Microsoft.Extensions.CodeGeneration.Utils,ship
 Microsoft.Extensions.CodeGenerators.Mvc,ship
 Microsoft.Extensions.CommandLineUtils,ship
 Microsoft.Extensions.CommandLineUtils.Sources,noship
-Microsoft.Extensions.CompilationAbstractions,ship
+Microsoft.Extensions.CompilationAbstractions,noship
 Microsoft.Extensions.Configuration,ship
 Microsoft.Extensions.Configuration.Abstractions,ship
 Microsoft.Extensions.Configuration.Binder,ship


### PR DESCRIPTION
Mark Microsoft.Extensions.CompilationAbstractions as noship as it is a dnx package
