### PR TITLE
Turn of ignore errors on split packages

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -41,5 +41,5 @@ use-standard-lifecycle
   exec program='dotnet' commandline='run -f net451 -- ${args}' workingdir='${COHERENCE_BUILD_PROJ}'
 
   var splitPackagesExe = '${Directory.GetFiles(SPLIT_PROJECT_DOWNLOAD, "SplitPackages.exe", SearchOption.AllDirectories).First()}'
-  var splitArgs = '--source ${BUILD_DIR} --csv ${SPLIT_CSV_PATH} --destination ${TARGET_DIR} --ignore-errors'
+  var splitArgs = '--source ${BUILD_DIR} --csv ${SPLIT_CSV_PATH} --destination ${TARGET_DIR}'
   exec program='${splitPackagesExe}' commandline='${splitArgs}' workingdir='${COHERENCE_BUILD_PROJ}'


### PR DESCRIPTION
Fail with a list of errors when there are inconsistencies between the packages from our build and the list of packages in the packages.csv CSV file.
