### PR TITLE
Create a new shipoob category for packages that ship separate from the main train

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ TestResults/
 .testPublish/
 *.sln.ide/
 _ReSharper.*/
-packages/
 artifacts/
 PublishProfiles/
 .vs/

--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -54,6 +54,7 @@ Microsoft.AspNetCore.Identity.Service,ship,include
 Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore,ship,include
 Microsoft.AspNetCore.Identity.Service.IntegratedWebClient,ship,include
 Microsoft.AspNetCore.Identity.Service.Mvc,ship,include
+Microsoft.AspNetCore.Identity.Service.Specification.Tests,ship,exclude
 Microsoft.AspNetCore.JsonPatch,ship,include
 Microsoft.AspNetCore.Localization,ship,include
 Microsoft.AspNetCore.Localization.Routing,ship,include

--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -184,7 +184,6 @@ Microsoft.Extensions.Process.Sources,noship,exclude
 Microsoft.Extensions.PropertyActivator.Sources,noship,exclude
 Microsoft.Extensions.PropertyHelper.Sources,noship,exclude
 Microsoft.Extensions.RazorViews.Sources,noship,exclude
-Microsoft.Extensions.RuntimeEnvironment.Sources,noship,exclude
 Microsoft.Extensions.SecretManager.Tools,ship,exclude
 Microsoft.Extensions.SecurityHelper.Sources,noship,exclude
 Microsoft.Extensions.StackTrace.Sources,noship,exclude

--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -18,7 +18,7 @@ Microsoft.AspNetCore.Authentication.Twitter,ship,include
 Microsoft.AspNetCore.Authorization,ship,include
 Microsoft.AspNetCore.AzureAppServicesIntegration,ship,include
 Microsoft.AspNetCore.AzureAppServices.HostingStartup,ship,include
-Microsoft.AspNetCore.AzureAppServices.SiteExtension,noship,exclude
+Microsoft.AspNetCore.AzureAppServices.SiteExtension,shipoob,exclude
 Microsoft.AspNetCore.Buffering,noship,exclude
 Microsoft.AspNetCore.ChunkingCookieManager.Sources,noship,exclude
 Microsoft.AspNetCore.CookiePolicy,ship,include
@@ -205,5 +205,5 @@ Microsoft.VisualStudio.Web.CodeGeneration.Templating,ship,exclude
 Microsoft.VisualStudio.Web.CodeGeneration.Tools,ship,exclude
 Microsoft.VisualStudio.Web.CodeGeneration.Utils,ship,exclude
 Microsoft.VisualStudio.Web.CodeGenerators.Mvc,ship,exclude
-Microsoft.Web.Xdt.Extensions,noship,exclude
+Microsoft.Web.Xdt.Extensions,shipoob,exclude
 RazorPageGenerator,noship,exclude

--- a/packages/packages.csv
+++ b/packages/packages.csv
@@ -176,6 +176,7 @@ Microsoft.Extensions.Logging.EventLog,ship,exclude
 Microsoft.Extensions.Logging.EventSource,ship,include
 Microsoft.Extensions.Logging.Testing,noship,exclude
 Microsoft.Extensions.Logging.TraceSource,ship,include
+Microsoft.Extensions.ObjectMethodExecutor.Sources,noship,exclude
 Microsoft.Extensions.ObjectPool,ship,include
 Microsoft.Extensions.Options,ship,include
 Microsoft.Extensions.Options.ConfigurationExtensions,ship,include

--- a/packages/packages.key.txt
+++ b/packages/packages.key.txt
@@ -1,0 +1,12 @@
+The packages.csv file lists all packages produced by the UniverseCoherence build. These are categorized by a few different criteria, and other parts of the build operate on those criteria.
+
+Package: The name of the package
+
+Category: The package shipping category
+- noship: Internal infrastructure only. These will be uploaded to myget, but they won't get signed or uploaded to nuget.org.
+- ship: Official product packages. These will be uploaded to myget, signed, and uploaded to nuget.org
+- shipoob: Exceptions like Microsoft.AspNetCore.AzureAppServices.SiteExtension. These are official product packages that get uploaded to myget and signed but they do not ship to nuget.org, they ship via other distribution mechanisms. 
+
+OptimizedCache: Should this package be included when we build an optimized package cache (e.g. shipping product assemblies only)
+- include
+- exclude


### PR DESCRIPTION
This should cause the creation of a new shipoob directory in the drops folder. From there I can modify coherence-signed to sign these packages without mixing them with the normal shipping packages.