### PR TITLE
Added support for generating a file which lists the dependencies that…

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NuGetPublishFeed>https://dotnet.myget.org/f/aspnetcore-ci-release</NuGetPublishFeed>
     <NpmRegistry>$(NuGetPublishFeed)/npm/</NpmRegistry>
-    <BuildDependsOn>$(BuildDependsOn);RunVerifier;RunSplitPackages;PublishNpmModules</BuildDependsOn>
+    <BuildDependsOn>$(BuildDependsOn);RunVerifier;_UpdateDependenciesFileInKorebuild;RunSplitPackages;PublishNpmModules</BuildDependsOn>
   </PropertyGroup>
   
   <Target Name="RunVerifier">
@@ -77,5 +77,43 @@
     <GetDotNetHost>
       <Output TaskParameter="ExecutablePath" PropertyName="DotNetPath" />
     </GetDotNetHost>
+  </Target>
+
+  <Target Name="_UpdateDependenciesFileInKorebuild">
+    <PropertyGroup>
+      <KoreBuildRepo>git@github.com:aspnet/KoreBuild.git</KoreBuildRepo>
+      <KoreBuildBranch>rel/2.0.0-preview2</KoreBuildBranch>
+      <KoreBuildCloneDirectory>$(RepositoryRoot).korebuild\</KoreBuildCloneDirectory>
+      <GitUser>ASP.NET Push Bot</GitUser>
+      <GitEmail>asplab@microsoft.com</GitEmail>
+      <GitAuthor>$(GitUser) &lt;$(GitEmail)&gt;</GitAuthor>
+      <GitConfigurationOptions>-c user.name=&quot;$(GitUser)&quot; -c user.email=&quot;$(GitEmail)&quot;</GitConfigurationOptions>
+      <SourceDependenciesFilePath>$(ArtifactsDir)dependencies.props</SourceDependenciesFilePath>
+      <KorebuildDependenciesFilePath>$(KoreBuildCloneDirectory)build\dependencies.props</KorebuildDependenciesFilePath>
+    </PropertyGroup>
+    
+    <RemoveDir Directories="$(KoreBuildCloneDirectory)" Condition="Exists('$(KoreBuildCloneDirectory)')" />
+    <Exec Command="git clone $(KoreBuildRepo) -b $(KoreBuildBranch) $(KoreBuildCloneDirectory)" />
+    
+    <Error Condition="!Exists('$(SourceDependenciesFilePath)')"
+      Text="Could not find dependencies file: '$(SourceDependenciesFilePath)''" />
+    
+    <Copy SourceFiles="$(SourceDependenciesFilePath)" DestinationFolder="$(KoreBuildCloneDirectory)build" />
+    
+    <Exec
+      Command="git $(GitConfigurationOptions) add $(KorebuildDependenciesFilePath)"
+      WorkingDirectory="$(KoreBuildCloneDirectory)" />
+
+    <Exec
+      Command="git $(GitConfigurationOptions) commit -q --author=&quot;$(GitAuthor)&quot; -m &quot;Updated dependencies&quot;"
+      IgnoreExitCode="true"
+      WorkingDirectory="$(KoreBuildCloneDirectory)">
+      <Output TaskParameter="ExitCode" PropertyName="CommitExitCode"/>
+    </Exec>
+
+    <Exec
+      Command="git $(GitConfigurationOptions) push -q $(KoreBuildRepo) $(KoreBuildBranch):$(KoreBuildBranch)"
+      WorkingDirectory="$(KoreBuildCloneDirectory)"
+      Condition="'$(CommitExitCode)'=='0'" />
   </Target>
 </Project>

--- a/tools/CoherenceBuild/CoherenceBuild.cs
+++ b/tools/CoherenceBuild/CoherenceBuild.cs
@@ -181,7 +181,11 @@ namespace CoherenceBuild
                 if (!nugetPackageFile.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
                 {
                     var packageInfo = GetPackageIdAndVersion(nugetPackageFile);
-                    var element = new XElement(packageInfo.Item1, packageInfo.Item2);
+
+                    // Even though having a '.' is valid in an xml element, dotnet restore does not like it, so
+                    // replace it.
+                    var elementName = packageInfo.Item1.Replace(".", "-");
+                    var element = new XElement(elementName, packageInfo.Item2);
                     propertyGroup.Add(element);
                 }
             }

--- a/tools/CoherenceBuild/Program.cs
+++ b/tools/CoherenceBuild/Program.cs
@@ -78,12 +78,12 @@ namespace CoherenceBuild
 
                 if (disableProductPackageVerification.HasValue())
                 {
-                   coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.ProductPackages;
+                    coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.ProductPackages;
                 }
 
                 if (disablePartnerPackageVerification.HasValue())
                 {
-                   coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.PartnerPackages;
+                    coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.PartnerPackages;
                 }
 
                 return coherenceBuild.Execute();

--- a/tools/CoherenceBuild/Program.cs
+++ b/tools/CoherenceBuild/Program.cs
@@ -78,12 +78,12 @@ namespace CoherenceBuild
 
                 if (disableProductPackageVerification.HasValue())
                 {
-                    coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.ProductPackages;
+                   coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.ProductPackages;
                 }
 
                 if (disablePartnerPackageVerification.HasValue())
                 {
-                    coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.PartnerPackages;
+                   coherenceBuild.VerifyBehavior &= CoherenceVerifyBehavior.All ^ CoherenceVerifyBehavior.PartnerPackages;
                 }
 
                 return coherenceBuild.Execute();


### PR DESCRIPTION
… were used during the build and pushes this file to Korebuild
Related to: https://github.com/aspnet/KoreBuild/issues/239

An example file: https://github.com/kichalla/KoreBuild/blob/dev/build/dependencies.props (**NOTE**: replace '.' with '-' in element names )

 