### PR TITLE
Support lineup packages

### DIFF
--- a/tools/CoherenceBuild/CoherenceVerifier.cs
+++ b/tools/CoherenceBuild/CoherenceVerifier.cs
@@ -121,6 +121,11 @@ namespace CoherenceBuild
                 Log.WriteInformation($"Skipping verification for external package {packageInfo.Identity}.");
                 return;
             }
+            else if (packageInfo.IsLineupPackage)
+            {
+                Log.WriteInformation($"Skipping verification for lineup package {packageInfo.Identity}.");
+                return;
+            }
             else if (PackagesToSkipVerification.Contains(packageInfo.Identity.Id))
             {
                 Log.WriteWarning($"Skipping verification for package {packageInfo.Identity} because it is in ignore list.");

--- a/tools/CoherenceBuild/PackageInfo.cs
+++ b/tools/CoherenceBuild/PackageInfo.cs
@@ -9,6 +9,8 @@ namespace CoherenceBuild
     {
         public bool IsPartnerPackage { get; set; }
 
+        public bool IsLineupPackage { get; set; }
+
         public PackageIdentity Identity { get; set; }
 
         public IEnumerable<PackageDependencyGroup> PackageDependencyGroups { get; set; }
@@ -32,7 +34,14 @@ namespace CoherenceBuild
             {
                 if (IsPartnerPackage)
                 {
+                    // these should be pushed first
                     return 1;
+                }
+
+                if (IsLineupPackage)
+                {
+                    // these should be pushed last
+                    return int.MaxValue;
                 }
 
                 if (ProductDependencies.Count == 0)

--- a/tools/CoherenceBuild/RepositoryInfo.cs
+++ b/tools/CoherenceBuild/RepositoryInfo.cs
@@ -14,6 +14,8 @@
 
         public string BuildDirectory { get; set; } = "build";
 
+        public string LineupPackageDirectory { get; set; } = "lineups";
+
         public string PackagesDestinationDirectory { get; set; }
     }
 }


### PR DESCRIPTION
Part of https://github.com/aspnet/KoreBuild/issues/239

Because lineups are a separate kind of nuget package, these are placed in a separate artifacts directory and must be handled differently during verification and push.